### PR TITLE
Take a resource

### DIFF
--- a/hphp/runtime/ext/phar/ext_phar.cpp
+++ b/hphp/runtime/ext/phar/ext_phar.cpp
@@ -59,9 +59,11 @@ static struct PharStreamWrapper : Stream::Wrapper {
       nullptr,
       SystemLib::s_PharClass
     );
-    String contents = ret.toString();
 
-    return req::make<MemFile>(contents.data(), contents.size());
+    if (!ret.isResource()) {
+      return nullptr;
+    }
+    return dyn_cast_or_null<File>(ret.asResRef());
   }
 
   virtual int access(const String& path, int mode) {


### PR DESCRIPTION
Switch the C++ side of ext_phar to expect a resource to be returned rather than a string.

This should work as advertised, but I've not actually tested it so...
